### PR TITLE
Changes package name inside install script to reflect new changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/scripts/background_control.sh
+++ b/scripts/background_control.sh
@@ -9,6 +9,6 @@ import TrackPlayer from \"react-native-track-player\";" index.js
 
 sed -i.bak "/registerComponent/a\\
 TrackPlayer.registerPlaybackService(() =>\
-  require('./node_modules/@adalo-components/adalo-audio-player/src/components/AudioPlayer/service.js'),\
+  require('./node_modules/@adalo/audio-player/src/components/AudioPlayer/service.js'),\
 );
 " index.js


### PR DESCRIPTION
### Problem
With the new packager changes, libraries no longer have the `@adalo/components` prefix. This package name was hard-coded in an install script in audio player.

### Solution
Change the script to reflect the changes.

### Related PRs
https://github.com/AdaloHQ/packager/pull/106
https://github.com/AdaloHQ/component-registry/pull/27