### PR TITLE
Bugfix/track overlap

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,6 @@
+{
+  "ignore_dirs": [
+    ".git",
+    "node_modules"
+  ]
+}

--- a/src/components/AudioPlayer/AudioPlayer.js
+++ b/src/components/AudioPlayer/AudioPlayer.js
@@ -63,7 +63,7 @@ class AudioPlayerSub extends Component {
 
     // ensure play/pause button matches playing prop
     let state = await TrackPlayer.getState()
-    if (state === 'playing' && !playing) {
+    if (state === TrackPlayer.STATE_PLAYING && !playing) {
       const { updatePlaying } = this.props
       updatePlaying(true)
     }
@@ -149,7 +149,7 @@ class AudioPlayerSub extends Component {
 
     // ensure play/pause button matches playing prop
     let playerState = await TrackPlayer.getState()
-    if (playerState == 'playing' && !playing) {
+    if (playerState == TrackPlayer.STATE_PLAYING && !playing) {
       updatePlaying(true)
     }
 

--- a/src/components/AudioPlayer/AudioPlayer.js
+++ b/src/components/AudioPlayer/AudioPlayer.js
@@ -1,17 +1,22 @@
 import React, { Component } from 'react'
-import TrackPlayer from 'react-native-track-player'
+import TrackPlayer, { getCurrentTrack } from 'react-native-track-player'
 import { v4 as uuid } from 'uuid'
 import ProgressBar from './ProgressBar'
 
 class AudioPlayerSub extends Component {
   constructor(props) {
     super(props)
+    this.state = { switching: false, startSwitch: false }
+
     // Sets up everything on react-native-track-player's end
     this.setup()
   }
 
   setup = async () => {
     await TrackPlayer.setupPlayer()
+
+    TrackPlayer.registerPlaybackService(() => require('./service'))
+
     TrackPlayer.updateOptions({
       // Whether the player should stop running when the app is closed on Android
       stopWithApp: true,
@@ -29,25 +34,46 @@ class AudioPlayerSub extends Component {
         TrackPlayer.CAPABILITY_PAUSE,
       ],
     })
-    const { track, playing, autoplay } = this.props
+
+    const { track, playing, autoplay, updatePlaying } = this.props
+
+    const id = uuid()
+
     // Adds the specified song to the track player to be ready to play
     await TrackPlayer.add({
       // Every track needs a unique id, not really used anywhere here though
-      id: uuid(),
+      id: id,
       url: track.url,
       title: track.title,
       artist: track.subtitle,
       artwork: track.artwork,
     })
-    // If player was already set to play, start playing
+
+    let isReady = (await TrackPlayer.getState()) === TrackPlayer.STATE_READY
+    while (!isReady) {
+      isReady = (await TrackPlayer.getState()) === TrackPlayer.STATE_READY
+    }
+
+    // If player was already set to play or set to autoplay, start playing
     if (playing || autoplay) {
       await TrackPlayer.play()
+      this.setState({ startSwitch: false })
+      updatePlaying(true)
     }
+
+    // ensure play/pause button matches playing prop
     let state = await TrackPlayer.getState()
-    if (state == 'playing' && !playing) {
+    if (state === 'playing' && !playing) {
       const { updatePlaying } = this.props
       updatePlaying(true)
     }
+
+    // clean out unnecessary tracks in TrackPlayer queue
+    await TrackPlayer.getQueue().then(queue => {
+      if (queue.length > 1) {
+        TrackPlayer.remove(queue[0].id)
+      }
+    })
   }
 
   // Generic seeking function used by index to handle skip and rewind.
@@ -59,12 +85,30 @@ class AudioPlayerSub extends Component {
   }
 
   checkTrack = async () => {
-    // Check if the track has changed
+    // checkTrack = async (prevProps) => {
+    /*
+    Check if the current track in TrackPlayer (oldTrack) is different
+    than the track in props. This handles the case where a user
+    switches to a screen where the component is already rendered
+    (example: using the back button)
+    */
+    const {
+      topScreen,
+      track,
+      playing,
+      updatePlaying,
+      prevProgress,
+      duration,
+      autoplay,
+    } = this.props
+
     const id = await TrackPlayer.getCurrentTrack()
     const oldTrack = await TrackPlayer.getTrack(id)
-    if (oldTrack?.url != this.props.track.url) {
+
+    if (topScreen && !this.state.switching && oldTrack?.url != track.url) {
+      this.setState({ switching: true })
+
       const id = uuid()
-      const { track, playing, autoplay, updatePlaying } = this.props
       await TrackPlayer.add({
         id,
         url: track.url,
@@ -72,59 +116,92 @@ class AudioPlayerSub extends Component {
         artist: track.subtitle,
         artwork: track.artwork,
       })
-      TrackPlayer.skip(id)
+
+      await TrackPlayer.skip(id)
+
+      //check that new track is ready before playing
+      let isReady = (await TrackPlayer.getState()) == TrackPlayer.STATE_READY
+      while (!isReady) {
+        isReady = (await TrackPlayer.getState()) == TrackPlayer.STATE_READY
+      }
+
+      // reset prevProgress if already
+      // else, revert to previous progress if returning to a previous screen
+      if (Math.round(prevProgress * 100) / 100 === 1) {
+        this.props.updatePrevProgress(0)
+      } else if (prevProgress !== 0) {
+        const { updatePlayed, updateProgress, updatePrevProgress } = this.props
+        const newPlayed = duration * prevProgress
+        updatePlayed(newPlayed)
+        updateProgress(prevProgress)
+        updatePrevProgress(0)
+        const abc = await TrackPlayer.seekTo(newPlayed)
+      }
+
       // If player was already set to play, start playing
       if (playing || autoplay) {
         await TrackPlayer.play()
         updatePlaying(true)
       }
-      let state = await TrackPlayer.getState()
-      if (state == 'playing' && !playing) {
-        const { updatePlaying } = this.props
-        updatePlaying(true)
-      }
+
+      this.setState({ switching: false, startSwitch: false })
     }
 
-    /*TrackPlayer.getCurrentTrack().then(id => {
-      TrackPlayer.getTrack(id).then(oldTrack => {
-        if (oldTrack?.url != this.props.track.url) {
-          const id = uuid()
-          const { track, playing, autoplay } = this.props
-          TrackPlayer.add({
-            id,
-            url: track.url,
-            title: track.title,
-            artist: track.subtitle,
-            artwork: track.artwork,
-          }).then(() => {
-            TrackPlayer.skip(id);
-            // If player was already set to play, start playing
-            if (playing || autoplay) {
-              await TrackPlayer.play()
-            }
-            let state = await TrackPlayer.getState()
-            if (state == 'playing' && !playing) {
-              const { updatePlaying } = this.props
-              updatePlaying(true)
-            }
-          })
-        }
-      })
-    })*/
+    // ensure play/pause button matches playing prop
+    let playerState = await TrackPlayer.getState()
+    if (playerState == 'playing' && !playing) {
+      updatePlaying(true)
+    }
+
+    // clean out unnecessary tracks in TrackPlayer queue
+    await TrackPlayer.getQueue().then(queue => {
+      if (queue.length > 1) {
+        TrackPlayer.remove(queue[0].id)
+      }
+    })
+  }
+
+  shouldComponentUpdate(nextProps) {
+    const {
+      active,
+      progress,
+      playing,
+      updatePrevProgress,
+      updatePlaying,
+    } = this.props
+
+    // pauses track when changing screens
+    if (!nextProps.active && active !== nextProps.active && playing) {
+      TrackPlayer.pause()
+      updatePlaying(false)
+      this.setState({ startSwitch: true })
+      updatePrevProgress(progress)
+    }
+
+    return true
   }
 
   // When props change
   componentDidUpdate(prevProps) {
-    // Check if the play/pause controls have changed
-    if (prevProps.playing != this.props.playing) {
-      this.props.playing ? TrackPlayer.play() : TrackPlayer.pause()
+    const { playing } = this.props
+
+    this.checkTrack(prevProps)
+
+    // Update play/pause if it changed
+    if (prevProps.playing != playing) {
+      playing ? TrackPlayer.play() : TrackPlayer.pause()
     }
-    this.checkTrack()
   }
 
   // Render Progress Bar
   render() {
-    return <ProgressBar {...this.props} />
+    return (
+      <ProgressBar
+        {...this.props}
+        switching={this.state.switching}
+        startSwitch={this.state.startSwitch}
+      />
+    )
   }
 }
 

--- a/src/components/AudioPlayer/AudioPlayer.web.js
+++ b/src/components/AudioPlayer/AudioPlayer.web.js
@@ -39,24 +39,41 @@ export default class AudioPlayerSub extends Component {
 
   componentDidUpdate(prevProps) {
     const {
-      track: { url },
+      track: { url, title: title },
       playing,
       progress,
-      endSong,
+      updatePlaying,
+      topScreen,
     } = this.props
     const {
-      track: { url: prevUrl },
+      track: { url: prevUrl, title: prevTitle },
       playing: prevPlaying,
     } = prevProps
+
     if (url !== prevUrl) {
       this.addUrl(url)
     }
+
     if (playing !== prevPlaying) {
       if (playing && this.player.src) this.player.play()
       else if (!playing && this.player.src) this.player.pause()
     }
-    // Check if the song has ended, and if so call the endSong function from index
-    if (Math.round(progress * 100) / 100 === 1) endSong()
+
+    // If song has ended, reset progress and trigger end action
+    if (topScreen && Math.round(progress * 10000) / 10000 === 1) {
+      const { updatePlayed, updateProgress, endSong } = this.props
+      this.player.currentTime = 0
+      updatePlayed(0)
+      updateProgress(0)
+
+      endSong()
+    }
+
+    // Pauses video when navigating to different screen
+    if (!topScreen && playing) {
+      this.player.pause()
+      updatePlaying(false)
+    }
   }
 
   addUrl = url => {
@@ -126,6 +143,7 @@ export default class AudioPlayerSub extends Component {
     } = this.props
     // Formats duration and played using "hhmmss", padding the numbers and
     // presenting it as a string.
+
     const durationFormatted = hhmmss(
       endTimeFormat == 1 ? duration : duration - played
     )
@@ -162,6 +180,7 @@ export default class AudioPlayerSub extends Component {
     const timeFontStyles = {
       fontFamily: _fonts.body,
     }
+
     return (
       <View style={(styles.wrapper, paddingStyles)}>
         <audio ref={ref => (this.player = ref)} />

--- a/src/components/AudioPlayer/index.js
+++ b/src/components/AudioPlayer/index.js
@@ -18,6 +18,8 @@ class AudioPlayer extends Component {
       playable: true,
       // Proportion of song played (from 0 to 1)
       progress: 0,
+      // Proportion of previous song played (0 if no previous song)
+      prevProgress: 0,
       // Duration of song
       duration: 0,
       // Time played of song (in seconds)
@@ -142,13 +144,16 @@ class AudioPlayer extends Component {
   updatePlayable = bool => {
     this.setState({ playable: bool })
   }
+  updatePrevProgress = newProgress => {
+    this.setState({ prevProgress: newProgress })
+  }
 
   endSong = () => {
     const { endAction } = this.props
     if (endAction) endAction()
   }
 
-  // Delcares ref to audio player component. Enables index to do playback
+  // Declares ref to audio player component. Enables index.js to do playback
   // control on the audio player subcomponent
   ref = audioPlayer => {
     this.audioPlayer = audioPlayer
@@ -170,6 +175,8 @@ class AudioPlayer extends Component {
       autoplay,
       editor,
       _fonts,
+      active,
+      topScreen,
     } = this.props
     const { width } = this.state
     const artworkWidth = (width * artwork.artworkPercent) / 100
@@ -285,6 +292,7 @@ class AudioPlayer extends Component {
                 played={this.state.played}
                 duration={this.state.duration}
                 progress={this.state.progress}
+                prevProgress={this.state.prevProgress}
                 playing={this.state.playing}
                 track={this.state.track}
                 seek={this.seek}
@@ -294,11 +302,14 @@ class AudioPlayer extends Component {
                 updatePlayed={this.updatePlayed}
                 updatePlaying={this.updatePlaying}
                 updatePlayable={this.updatePlayable}
+                updatePrevProgress={this.updatePrevProgress}
                 width={width}
                 autoplay={autoplay}
                 editor={editor}
                 endSong={this.endSong}
                 _fonts={_fonts}
+                active={active}
+                topScreen={topScreen}
               />
               <ControlScheme {...buttonConfig} {...this.state} />
             </View>
@@ -322,6 +333,7 @@ class AudioPlayer extends Component {
                 played={this.state.played}
                 duration={this.state.duration}
                 progress={this.state.progress}
+                prevProgress={this.state.prevProgress}
                 playing={this.state.playing}
                 track={this.state.track}
                 seek={this.seek}
@@ -331,11 +343,14 @@ class AudioPlayer extends Component {
                 updatePlayed={this.updatePlayed}
                 updatePlaying={this.updatePlaying}
                 updatePlayable={this.updatePlayable}
+                updatePrevProgress={this.updatePrevProgress}
                 width={width}
                 autoplay={autoplay}
                 editor={editor}
                 endSong={this.endSong}
                 _fonts={_fonts}
+                active={active}
+                topScreen={topScreen}
               />
               {title != '' ? (
                 <Text style={dynamicStyles.title}>{title}</Text>
@@ -372,6 +387,7 @@ class AudioPlayer extends Component {
                 played={this.state.played}
                 duration={this.state.duration}
                 progress={this.state.progress}
+                prevProgress={this.state.prevProgress}
                 playing={this.state.playing}
                 track={this.state.track}
                 seek={this.seek}
@@ -381,11 +397,14 @@ class AudioPlayer extends Component {
                 updatePlayed={this.updatePlayed}
                 updatePlaying={this.updatePlaying}
                 updatePlayable={this.updatePlayable}
+                updatePrevProgress={this.updatePrevProgress}
                 width={width}
                 autoplay={autoplay}
                 editor={editor}
                 endSong={this.endSong}
                 _fonts={_fonts}
+                active={active}
+                topScreen={topScreen}
               />
             </View>
           )}


### PR DESCRIPTION
**Problem:** Track did not stop after navigating to a different screen, so different tracks would play over each other. Progress did also not reset after changing from one track player to another. This caused the action at the end of a song to trigger twice. Primarily a mobile problem.

**Solution:** Paused and reset progress on all tracks before moving to a different screen. As an exception, when navigating back to a previous screen, progress will resume from its previous part of the track. Autoplay should still work and when navigating to a different page while playing a track, the next track will start playing automatically.