### PR TITLE
Make time font color controllable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/src/components/AudioPlayer/AudioPlayer.web.js
+++ b/src/components/AudioPlayer/AudioPlayer.web.js
@@ -150,6 +150,7 @@ export default class AudioPlayerSub extends Component {
       borderSize,
       borderShadow,
       endTimeFormat,
+      timeFontColor,
       markerColor,
       width,
       _fonts,
@@ -192,6 +193,7 @@ export default class AudioPlayerSub extends Component {
     const trackLength = width - padding * 2
     const timeFontStyles = {
       fontFamily: _fonts.body,
+      color: timeFontColor,
     }
 
     return (

--- a/src/components/AudioPlayer/ProgressBar.js
+++ b/src/components/AudioPlayer/ProgressBar.js
@@ -90,6 +90,7 @@ class ProgressBar extends TrackPlayer.ProgressComponent {
       borderSize,
       borderShadow,
       endTimeFormat,
+      timeFontColor,
       markerColor,
       width,
       _fonts,
@@ -187,6 +188,7 @@ class ProgressBar extends TrackPlayer.ProgressComponent {
     const trackLength = width - padding * 2
     const timeFontStyles = {
       fontFamily: _fonts.body,
+      color: timeFontColor,
     }
     return (
       <View style={(styles.wrapper, paddingStyles)}>

--- a/src/components/AudioPlayer/manifest.json
+++ b/src/components/AudioPlayer/manifest.json
@@ -225,6 +225,12 @@
               }
             ]
           }
+        },
+        {
+          "name": "timeFontColor",
+          "displayName": "Time Text Color",
+          "type": "color",
+          "default": "@text"
         }
       ]
     },


### PR DESCRIPTION
Add option to control the text color in the progress bar. Useful for dark mode designs.