### PR TITLE
Fixes autoplay bug on ios

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/src/components/AudioPlayer/AudioPlayer.js
+++ b/src/components/AudioPlayer/AudioPlayer.js
@@ -35,6 +35,13 @@ class AudioPlayerSub extends Component {
 
     const { track, playing, autoplay, updatePlaying } = this.props
 
+    if (
+      (await TrackPlayer.getState()) === TrackPlayer.STATE_PAUSED &&
+      autoplay
+    ) {
+      await TrackPlayer.reset()
+    }
+
     // Adds the specified song to the track player to be ready to play
     const id = uuid()
     await TrackPlayer.add({

--- a/src/components/AudioPlayer/AudioPlayer.js
+++ b/src/components/AudioPlayer/AudioPlayer.js
@@ -68,6 +68,8 @@ class AudioPlayerSub extends Component {
     let state = await TrackPlayer.getState()
     if (state === TrackPlayer.STATE_PLAYING && !playing) {
       updatePlaying(true)
+    } else if (state === TrackPlayer.STATE_PAUSED && playing) {
+      updatePlaying(false)
     }
 
     // clean out unnecessary tracks in TrackPlayer queue
@@ -159,6 +161,8 @@ class AudioPlayerSub extends Component {
     let playerState = await TrackPlayer.getState()
     if (playerState === TrackPlayer.STATE_PLAYING && !playing) {
       updatePlaying(true)
+    } else if(playerState === TrackPlayer.STATE_PAUSED && playing) {
+      updatePlaying(false)
     }
 
     // clean out unnecessary tracks in TrackPlayer queue
@@ -201,6 +205,7 @@ class AudioPlayerSub extends Component {
     // Update play/pause if it changed
     if (prevProps.playing !== playing) {
       playing ? TrackPlayer.play() : TrackPlayer.pause()
+
     }
   }
 

--- a/src/components/AudioPlayer/AudioPlayer.web.js
+++ b/src/components/AudioPlayer/AudioPlayer.web.js
@@ -68,6 +68,7 @@ export default class AudioPlayerSub extends Component {
       updateProgress(0)
 
       endSong()
+      updatePlaying(false)
     }
 
     // Pauses audio when navigating to different screen


### PR DESCRIPTION
Autoplay would not occur on ios after the screen was navigated away from.

Fix: reset TrackPlayer when a screen is navigated to, the TrackPlayer state is paused, and autoplay is on