### PR TITLE
Bugfix/actions on audio player

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/src/components/AudioPlayer/ProgressBar.js
+++ b/src/components/AudioPlayer/ProgressBar.js
@@ -11,6 +11,7 @@ class ProgressBar extends TrackPlayer.ProgressComponent {
       seeking: false,
       seekingValue: 0,
       ending: false,
+      endActionRan: false,
     }
   }
 
@@ -44,7 +45,7 @@ class ProgressBar extends TrackPlayer.ProgressComponent {
   // resets progress to zero and calls on the action for the end of a song
   endTrack = async () => {
     const { updatePlayed, updateProgress, topScreen, endSong } = this.props
-    this.setState({ ending: true })
+    this.setState({ ending: true, endActionRan: true })
 
     updateProgress(0)
     updatePlayed(0)
@@ -58,11 +59,14 @@ class ProgressBar extends TrackPlayer.ProgressComponent {
   // the render function in ProgressBar, not the AudioPlayerSub, so if there are differences
   // between the new props and the old props, don't rerender.
   // Prevents an infinite loop.
-  shouldComponentUpdate(nextProps) {
+  shouldComponentUpdate(nextProps, nextState) {
     const { played, duration, progress, topScreen, startSwitch } = this.props
 
-    // if song ended, reset track progress and call the endSong function from index.js
-    if (Math.round(progress * 100) / 100 === 1 && !this.state.ending) {
+    if (
+      Math.floor(progress * 100) / 100 === 1 &&
+      !this.state.ending &&
+      !nextState.endActionRan
+    ) {
       this.endTrack()
     }
 

--- a/src/components/AudioPlayer/ProgressBar.js
+++ b/src/components/AudioPlayer/ProgressBar.js
@@ -65,6 +65,7 @@ class ProgressBar extends TrackPlayer.ProgressComponent {
     if (
       Math.floor(progress * 100) / 100 === 1 &&
       !this.state.ending &&
+      !this.state.endActionRan &&
       !nextState.endActionRan
     ) {
       this.endTrack()
@@ -124,6 +125,9 @@ class ProgressBar extends TrackPlayer.ProgressComponent {
     if (propPlayed !== played) {
       updateProgress(progress)
       updatePlayed(played)
+      if (progress < 1 && this.state.endActionRan) {
+        this.setState({ endActionRan: false })
+      }
     }
 
     // Boolean flag used to test if the player's position has properly changed


### PR DESCRIPTION
Create action was running multiple times when the audio player component finished playing on native apps. I added a check to see if the action has already ran to prevent duplicate runs