### PR TITLE
fixed regression from xcode 13 migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/src/components/AudioPlayer/AudioPlayer.js
+++ b/src/components/AudioPlayer/AudioPlayer.js
@@ -64,12 +64,10 @@ class AudioPlayerSub extends Component {
       updatePlaying(false)
     }
 
-    // clean out unnecessary tracks in TrackPlayer queue
-    await TrackPlayer.getQueue().then(queue => {
-      if (queue.length > 1) {
-        TrackPlayer.remove(0)
-      }
-    })
+    queue = await TrackPlayer.getQueue()
+    if (queue.length > 1) {
+      await TrackPlayer.removeUpcomingTracks()
+    }
   }
 
   // Generic seeking function used by index to handle skip and rewind.
@@ -158,11 +156,10 @@ class AudioPlayerSub extends Component {
     }
 
     // clean out unnecessary tracks in TrackPlayer queue
-    await TrackPlayer.getQueue().then(queue => {
-      if (queue.length > 1) {
-        TrackPlayer.remove(0)
-      }
-    })
+    const queue = await TrackPlayer.getQueue()
+    if (queue.length > 1) {
+      await TrackPlayer.removeUpcomingTracks()
+    }
   }
 
   shouldComponentUpdate(nextProps) {

--- a/src/components/AudioPlayer/AudioPlayer.js
+++ b/src/components/AudioPlayer/AudioPlayer.js
@@ -63,7 +63,7 @@ class AudioPlayerSub extends Component {
     } else if (state === State.Paused && playing) {
       updatePlaying(false)
     }
-    
+
     // clean out unnecessary tracks in TrackPlayer queue
     await TrackPlayer.getQueue().then(queue => {
       if (queue.length > 1) {
@@ -112,7 +112,8 @@ class AudioPlayerSub extends Component {
         artwork: track.artwork,
       })
 
-      await TrackPlayer.skip(0)
+      await TrackPlayer.skipToNext()
+      await TrackPlayer.remove(0)
 
       // prevents previous screen's audio playing on new screens' audio player
       if (keepPlaying) {

--- a/src/components/AudioPlayer/ProgressBar.js
+++ b/src/components/AudioPlayer/ProgressBar.js
@@ -14,11 +14,7 @@ const ProgressBar = props => {
   const [currentTrack, updateCurrentTrack] = useState(props.track)
 
   useEffect(() => {
-    const {
-      updatePlayed,
-      updateProgress,
-      updatePlaying,
-    } = props
+    const { updatePlayed, updateProgress, updatePlaying } = props
 
     updateDuration(duration)
     updatePlaying(false)
@@ -187,10 +183,6 @@ const ProgressBar = props => {
   if (Math.floor(progress * 100) / 100 === 1 && !ending && !endActionRan) {
     endTrack()
   }
-
-  TrackPlayer.getQueue().then(queue => {
-    console.log('queue2', queue)
-  })
 
   return (
     <View style={(styles.wrapper, paddingStyles)}>

--- a/src/components/AudioPlayer/ProgressBar.js
+++ b/src/components/AudioPlayer/ProgressBar.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Text, View, StyleSheet } from 'react-native'
 import TrackPlayer, { useProgress } from 'react-native-track-player'
 import MultiSlider from '@ptomasroos/react-native-multi-slider'
@@ -10,6 +10,25 @@ const ProgressBar = props => {
   const [ending, setEnding] = useState(false)
   const [recentlySeeked, setRecentlySeeked] = useState(false)
   const [endActionRan, setEndActionRan] = useState(false)
+
+  const [currentTrack, updateCurrentTrack] = useState(props.track)
+
+  useEffect(() => {
+    const {
+      updatePlayed,
+      updateProgress,
+      updatePlaying,
+    } = props
+
+    updateDuration(duration)
+    updatePlaying(false)
+    updateProgress(0)
+    updatePlayed(0)
+    const seek = async () => {
+      await TrackPlayer.seekTo(0)
+    }
+    seek()
+  }, [currentTrack, duration])
 
   // When the user clicks and holds on the slider
 
@@ -168,6 +187,10 @@ const ProgressBar = props => {
   if (Math.floor(progress * 100) / 100 === 1 && !ending && !endActionRan) {
     endTrack()
   }
+
+  TrackPlayer.getQueue().then(queue => {
+    console.log('queue2', queue)
+  })
 
   return (
     <View style={(styles.wrapper, paddingStyles)}>


### PR DESCRIPTION
The audio player was not updating when changing tracks on ios. This fixes the issue by forcing a skip forward whenever the track prop changes