### PR TITLE
reset queue when audio player is rendered

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.4.19",
+  "version": "1.4.20",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.4.20",
+  "version": "1.4.21",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/src/components/AudioPlayer/AudioPlayer.js
+++ b/src/components/AudioPlayer/AudioPlayer.js
@@ -112,9 +112,6 @@ class AudioPlayerSub extends Component {
       })
 
       await TrackPlayer.skipToNext()
-      // if ((await TrackPlayer.getQueue().length) > 0) {
-      //   await TrackPlayer.remove(0)
-      // }
 
       // prevents previous screen's audio playing on new screens' audio player
       if (keepPlaying) {
@@ -157,12 +154,6 @@ class AudioPlayerSub extends Component {
     } else if (playerState === State.Paused && playing) {
       updatePlaying(false)
     }
-
-    // clean out unnecessary tracks in TrackPlayer queue
-    const queue = await TrackPlayer.getQueue()
-    // if (queue.length > 1) {
-    //   await TrackPlayer.removeUpcomingTracks()
-    // }
   }
 
   shouldComponentUpdate(nextProps) {

--- a/src/components/AudioPlayer/AudioPlayer.js
+++ b/src/components/AudioPlayer/AudioPlayer.js
@@ -9,10 +9,15 @@ class AudioPlayerSub extends Component {
     this.state = { switching: false, startSwitch: false }
 
     // Sets up everything on react-native-track-player's end
-    this.setup()
+    // this.setup()
+  }
+
+  async componentDidMount() {
+    await this.setup()
   }
 
   setup = async () => {
+    //TODO: add a state variable to keep audio player from rendering?
     await TrackPlayer.setupPlayer()
 
     TrackPlayer.registerPlaybackService(() => require('./service'))
@@ -63,11 +68,6 @@ class AudioPlayerSub extends Component {
     } else if (state === State.Paused && playing) {
       updatePlaying(false)
     }
-
-    queue = await TrackPlayer.getQueue()
-    if (queue.length > 1) {
-      await TrackPlayer.removeUpcomingTracks()
-    }
   }
 
   // Generic seeking function used by index to handle skip and rewind.
@@ -102,6 +102,7 @@ class AudioPlayerSub extends Component {
       this.setState({ switching: true })
 
       const id = uuid()
+      await TrackPlayer.reset()
       await TrackPlayer.add({
         id,
         url: track.url,
@@ -111,9 +112,9 @@ class AudioPlayerSub extends Component {
       })
 
       await TrackPlayer.skipToNext()
-      if ((await TrackPlayer.getQueue().length) > 0) {
-        await TrackPlayer.remove(0)
-      }
+      // if ((await TrackPlayer.getQueue().length) > 0) {
+      //   await TrackPlayer.remove(0)
+      // }
 
       // prevents previous screen's audio playing on new screens' audio player
       if (keepPlaying) {
@@ -159,9 +160,9 @@ class AudioPlayerSub extends Component {
 
     // clean out unnecessary tracks in TrackPlayer queue
     const queue = await TrackPlayer.getQueue()
-    if (queue.length > 1) {
-      await TrackPlayer.removeUpcomingTracks()
-    }
+    // if (queue.length > 1) {
+    //   await TrackPlayer.removeUpcomingTracks()
+    // }
   }
 
   shouldComponentUpdate(nextProps) {

--- a/src/components/AudioPlayer/ProgressBar.js
+++ b/src/components/AudioPlayer/ProgressBar.js
@@ -30,6 +30,16 @@ const ProgressBar = props => {
     }
   }, [currentTrack, duration])
 
+  useEffect(() => {
+    if (
+      Math.floor(position) / Math.floor(duration) === 1 &&
+      !ending &&
+      !endActionRan
+    ) {
+      endTrack()
+    }
+  }, [position, duration])
+
   // When the user clicks and holds on the slider
 
   const startSeek = () => {
@@ -65,13 +75,11 @@ const ProgressBar = props => {
     } = props
     setEnding(true)
     setEndActionRan(true)
-
     updatePlaying(false)
     updateProgress(0)
     updatePlayed(0)
     await TrackPlayer.seekTo(0)
     if (topScreen) endSong()
-
     setEnding(false)
   }
 
@@ -181,11 +189,6 @@ const ProgressBar = props => {
   const trackLength = width - padding * 2
   const timeFontStyles = {
     fontFamily: _fonts.body,
-  }
-
-  // if song ended, reset track progress and call the endSong function from index.js
-  if (Math.floor(progress * 100) / 100 === 1 && !ending && !endActionRan) {
-    endTrack()
   }
 
   return (


### PR DESCRIPTION
Instead of clearing out the queue after a track is added, the queue is now reset when the audio player first loads. 