### PR TITLE
update track when magic text loads in

### DIFF
--- a/dist/input/runtime.js
+++ b/dist/input/runtime.js
@@ -1,1 +1,3 @@
-export {    AudioPlayer as AudioPlayer,  } from '../../index.js'
+export {
+  AudioPlayer as AudioPlayer,
+} from '../../index.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.4.22",
+  "version": "1.4.23",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/src/components/AudioPlayer/index.js
+++ b/src/components/AudioPlayer/index.js
@@ -35,6 +35,34 @@ class AudioPlayer extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    const { url, title, subtitle, artwork, editor } = this.props
+    if (prevProps !== this.props && !editor) {
+      this.setState({
+        // Controls play/pause buttons, as well as playback
+        playing: false,
+        // Validity of url being played
+        playable: true,
+        // Proportion of song played (from 0 to 1)
+        progress: 0,
+        // Proportion of previous song played (0 if no previous song)
+        prevProgress: 0,
+        // Duration of song
+        duration: 0,
+        // Time played of song (in seconds)
+        played: 0,
+        // Info for the specific song currently playing.
+        track: {
+          url,
+          title,
+          subtitle,
+          artwork: artwork.artworkURL,
+        },
+        width: null,
+      })
+    }
+  }
+
   // Taken from range-slider code Jeremy wrote to dynamically change width
   handleLayout = ({ nativeEvent }) => {
     const { width } = (nativeEvent && nativeEvent.layout) || {}


### PR DESCRIPTION
Audio linked to the component as magic text (a text field in the database, from a text input, etc.) wasn't playing. The track wasn't being updated when the magic text loaded in so the url stayed blank. I added a `componentDidUpdate` function to handle this situation.