### PR TITLE
812 audio player crashing

### DIFF
--- a/dist/input/runtime.js
+++ b/dist/input/runtime.js
@@ -1,3 +1,1 @@
-export {
-  AudioPlayer as AudioPlayer,
-} from '../../index.js'
+export { AudioPlayer } from '../../index.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "3.0.6",
+  "version": "1.4.46",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.4.25",
+  "version": "1.4.26",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.4.30",
+  "version": "3.0.6",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.4.26",
+  "version": "1.4.30",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@ptomasroos/react-native-multi-slider": "^2.2.2",
     "moment": "^2.26.0",
     "react-native-swift": "^1.2.3",
-    "react-native-track-player": "^2.1.2",
+    "react-native-track-player": "^2.1.4",
     "react-native-vector-icons": "^6.6.0",
     "uuid": "^3.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.4.46",
+  "version": "1.4.48",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/src/components/AudioPlayer/index.js
+++ b/src/components/AudioPlayer/index.js
@@ -198,6 +198,16 @@ class AudioPlayer extends Component {
       keepPlaying,
     } = this.props
     const { width, track } = this.state
+
+    // If the track URL isn't available, the audio player will crash native apps.
+    // Display a simple message notifying the user of the problem, and prevent the
+    // player from loading and crashing the app.
+    // The URL is usually unavailable in the editor, which doesn't cause any harm, so
+    // allow the audio player to load in that context.
+    if (!editor && !track?.url) {
+      return <Text>Unable to load audio player, audio track URL unavailable.</Text>
+    }
+
     const artworkWidth = (width * artwork.artworkPercent) / 100
     const dynamicStyles = {
       artwork: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5590,10 +5590,10 @@ react-native-swift@^1.2.3:
     "@raydeck/xcode" "^2.2.0"
     glob "^7.1.2"
 
-react-native-track-player@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/react-native-track-player/-/react-native-track-player-2.1.2.tgz#34d387b8c1b2e6895f569d35137d2bc6524a9f85"
-  integrity sha512-tZw9/4Ft7EtKtWDZuregBEXjXv++7WT7BvaXDk+lKCL/e3FQI5zyiwECfM18sk6raeMs7ItBxNsDKryCf9mMUA==
+react-native-track-player@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/react-native-track-player/-/react-native-track-player-2.1.4.tgz#5e75000e382c4b8ac770b53cd6463b191c38c5ea"
+  integrity sha512-pfco6xrUCCdsfazRg7hJS+V9h+JZ24bj2ZNt5Af46wwmIpmD0lYT2Ekr6ggH6/qnCcfDBeNIK5XsrtQCPCaujg==
 
 react-native-vector-icons@^6.6.0:
   version "6.6.0"


### PR DESCRIPTION
## Problem

In native apps, the audio player is loading before the audio track URL is available, as that data is retrieved asynchronously from the Adalo database.  

## Solution

Check that the track URL is passed to the player before it is loaded.  If it is not, only display an error message.  Usually, once the player data is available, the player will load again and the user never sees the error message.


