### PR TITLE
Fix/Audio Player plays even if autoplay is off on Native iOS

### DIFF
--- a/dist/input/runtime.js
+++ b/dist/input/runtime.js
@@ -1,1 +1,1 @@
-export { AudioPlayer } from '../../index.js'
+export {    AudioPlayer as AudioPlayer,  } from '../../index.js'

--- a/dist/input/runtime.js
+++ b/dist/input/runtime.js
@@ -1,1 +1,0 @@
-export {    AudioPlayer as AudioPlayer,  } from '../../index.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.4.48",
+  "version": "1.5.0",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/src/components/AudioPlayer/AudioPlayer.js
+++ b/src/components/AudioPlayer/AudioPlayer.js
@@ -101,6 +101,7 @@ class AudioPlayerSub extends Component {
       this.setState({ switching: true })
 
       const id = uuid()
+
       await TrackPlayer.reset()
       await TrackPlayer.add({
         id,
@@ -109,6 +110,10 @@ class AudioPlayerSub extends Component {
         artist: track.subtitle,
         artwork: track.artwork,
       })
+
+      if (Platform.OS === 'android') {
+        await TrackPlayer.skipToNext()
+      }
 
       // prevents previous screen's audio playing on new screens' audio player
       if (keepPlaying) {

--- a/src/components/AudioPlayer/AudioPlayer.js
+++ b/src/components/AudioPlayer/AudioPlayer.js
@@ -110,8 +110,6 @@ class AudioPlayerSub extends Component {
         artwork: track.artwork,
       })
 
-      await TrackPlayer.skipToNext()
-
       // prevents previous screen's audio playing on new screens' audio player
       if (keepPlaying) {
         await TrackPlayer.pause()


### PR DESCRIPTION
## Problem
Audio player plays automatically even if autoplay is off.
This happens because we call a function in the track player called `skipToNext`, which changes the state to `playing` and so on by our code it starts the player.

## Solution
Remove the line where it calls `skipToNext`. It proved to be useless and causes no harm to be removed.
As this affects both iOS and Android, tests were ran on both of them for some cases described in the Trello card attached.
This line was added a modified in previous PRs, which led to different behaviors.

## Preview
https://user-images.githubusercontent.com/28742636/224839563-21e066f0-e174-4234-9b4c-bff433832e79.mov

