### PR TITLE
Reverts compatibility change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",

--- a/scripts/background_control.sh
+++ b/scripts/background_control.sh
@@ -4,7 +4,7 @@ set -x
 
 project_path=$(pwd)
 
-sed -i.bak "/import { name as appName }/a\\
+sed -i.bak "/import {name as appName}/a\\
 import TrackPlayer from \"react-native-track-player\";" index.js
 
 sed -i.bak "/registerComponent/a\\


### PR DESCRIPTION
Related to:
- https://github.com/AdaloHQ/packager/pull/437
- https://github.com/AdaloHQ/template-app/pull/70

Turns out that the change made to the React Native index.js wasn't compatible with a bunch of other components, so when the above 2 PRs are merged `@adalo/audio-player@1.5.5` can also be activated.