### PR TITLE
Update react-native-material-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/audio-player",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "license": "MIT",
   "author": "Adalo",
   "main": "index.js",
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.10.0",
-    "@protonapp/react-native-material-ui": "^2.0.9",
+    "@protonapp/react-native-material-ui": "^2.0.10",
     "@ptomasroos/react-native-multi-slider": "^2.2.2",
     "moment": "^2.26.0",
     "react-native-swift": "^1.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1938,10 +1938,10 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@protonapp/react-native-material-ui@^2.0.9":
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/@protonapp/react-native-material-ui/-/react-native-material-ui-2.0.9.tgz#f569626d0608b0c35200cddba1c585156fc40020"
-  integrity sha512-ty3hmhJIqsBd4rz8Qt2pQcpkACtEcYwio/JDLBfZgZQKLOF0r0Ckmgyc+l8wTzrfLp1uFEAM76V2NMjZ8RzBPA==
+"@protonapp/react-native-material-ui@^2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@protonapp/react-native-material-ui/-/react-native-material-ui-2.0.10.tgz#ae63927f79e306cd78516c3b2893d5614606d44e"
+  integrity sha512-ZXnh084AvEVb/rJ3Kcb6HCdjdnu5dQQ2ldJFCe4z4Fsc/hYywi37E6WMb4lDCHimveJwsVXOBd3sS2zO+jJGGg==
   dependencies:
     color "3.1.0"
     hoist-non-react-statics "^2.5.5"


### PR DESCRIPTION
## Problem
We specify a slightly outadted version of react-native-material-ui, meaning that custom icons' colors don't get applied.

## Solution
Update version.

## Related PRs
https://github.com/AdaloHQ/star-rating-component/pull/4
https://github.com/AdaloHQ/iap/pull/40
https://github.com/AdaloHQ/stopwatch/pull/39